### PR TITLE
Travis-CI added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+
+before_install:
+- sudo apt-get update
+
+install:
+- sudo apt-get install -qq git g++ apache2 libapr1-dev libaprutil1-dev patch binutils make devscripts
+
+before_script:
+- cd src
+- ./build_modssl_with_npn.sh
+- chmod +x ./build/gyp_chromium
+
+script:
+- make BUILDTYPE=Release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 mod-spdy
 ========
 
+[![Build Status](https://travis-ci.org/eousphoros/mod-spdy.svg?branch=master)](https://travis-ci.org/eousphoros/mod-spdy)
+
 OpenSSL 1.0.1(g) and Apache 2.4.7 port for mod-ssl with npn support and mod-spdy. Tested under Ubuntu 14.04 by eousphoros, tested under Ubuntu 13.10 by René Kijewski
 
 Status: Functional. Cleanup pending.


### PR DESCRIPTION
I have added a configuration file for Travis CI to test the build process. Travis automatically runs the build process for every pull request. In the future this script could be extended to setup a working apache configuration and do some functional SPDY tests.

You can see my recent builds at: https://travis-ci.org/digineo/mod-spdy/builds
