### PR TITLE
Apache2.4.7: update to openssl 1.0.1i

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ mod-spdy
 
 [![Build Status](https://travis-ci.org/eousphoros/mod-spdy.svg?branch=master)](https://travis-ci.org/eousphoros/mod-spdy)
 
-OpenSSL 1.0.1(h) and Apache 2.4.7 port for mod-ssl with npn support and mod-spdy. Tested under Ubuntu 14.04 by eousphoros, tested under Ubuntu 13.10 by René Kijewski. Travic-CI testing by Julian K.
+OpenSSL 1.0.1(i) and Apache 2.4.7 port for mod-ssl with npn support and mod-spdy. Tested under Ubuntu 14.04 by eousphoros, tested under Ubuntu 14.04 by René Kijewski. Travic-CI testing by Julian K.
 
 Status: Functional. Cleanup pending.
 
-apache2-2.4.7-1ubuntu1 + mod-ssl(npn,1.0.1h) + mod-spdy
+apache2-2.4.7-1ubuntu1 + mod-ssl(npn,1.0.1i) + mod-spdy
 
 https://www.ssllabs.com/ssltest/analyze.html?d=blck.io NPN:  spdy/3.1 spdy/3 spdy/2 http/1.1 x-mod-spdy/0.9.4.1-b1cbd2b
 

--- a/src/build_modssl_with_npn.sh
+++ b/src/build_modssl_with_npn.sh
@@ -104,7 +104,7 @@ function uncompress_file {
   fi
 }
 
-OPENSSL_SRC_TGZ_URL="http://www.openssl.org/source/openssl-1.0.1h.tar.gz"
+OPENSSL_SRC_TGZ_URL="http://www.openssl.org/source/openssl-1.0.1i.tar.gz"
 APACHE_HTTPD_SRC_TGZ_URL="http://archive.apache.org/dist/httpd/httpd-2.4.7.tar.gz"
 APACHE_HTTPD_MODSSL_NPN_PATCH_PATH="$(dirname $0)/scripts/mod_ssl_with_npn.patch"
 
@@ -123,7 +123,7 @@ cp $APACHE_HTTPD_MODSSL_NPN_PATCH_PATH $BUILDROOT/$APACHE_HTTPD_MODSSL_NPN_PATCH
 
 pushd $BUILDROOT >/dev/null
 
-download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ 8d6d684a9430d5cc98a62a5d8fbda8cf
+download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ c8dc151a671b9b92ff3e4c118b174972
 download_file $APACHE_HTTPD_SRC_TGZ_URL $APACHE_HTTPD_SRC_TGZ 9272aadaa2d702f6ae5758641d830d7f
 
 echo ""


### PR DESCRIPTION
Trivial upgrade, I only updated the version number and the md5sum.

Up and running on: https://www.ssllabs.com/ssltest/analyze.html?d=bib.vetmed.fu-berlin.de

See also: https://www.openssl.org/news/openssl-1.0.1-notes.html
