### PR TITLE
Apache 2.4.10

### DIFF
--- a/src/build_modssl_with_npn.sh
+++ b/src/build_modssl_with_npn.sh
@@ -104,7 +104,7 @@ function uncompress_file {
   fi
 }
 
-OPENSSL_SRC_TGZ_URL="https://www.openssl.org/source/openssl-1.0.1h.tar.gz"
+OPENSSL_SRC_TGZ_URL="https://www.openssl.org/source/openssl-1.0.1j.tar.gz"
 APACHE_HTTPD_SRC_TGZ_URL="https://archive.apache.org/dist/httpd/httpd-2.4.10.tar.gz"
 APACHE_HTTPD_MODSSL_NPN_PATCH_PATH="$(dirname $0)/scripts/mod_ssl_with_npn.patch"
 
@@ -123,7 +123,7 @@ cp $APACHE_HTTPD_MODSSL_NPN_PATCH_PATH $BUILDROOT/$APACHE_HTTPD_MODSSL_NPN_PATCH
 
 pushd $BUILDROOT >/dev/null
 
-download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ 8d6d684a9430d5cc98a62a5d8fbda8cf
+download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ f7175c9cd3c39bb1907ac8bba9df8ed3
 download_file $APACHE_HTTPD_SRC_TGZ_URL $APACHE_HTTPD_SRC_TGZ 9b5f9342f73a6b1ad4e8c4b0f3f5a159
 
 echo ""


### PR DESCRIPTION
Patch confirmed working on CentOS 6.6 x86_64 with Apache 2.4.10, OpenSSL-1.0.1j and SPDY all functioning correctly.
