### PR TITLE
Update to OpenSSL 1.0.1j

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ mod-spdy
 
 [![Build Status](https://travis-ci.org/eousphoros/mod-spdy.svg?branch=master)](https://travis-ci.org/eousphoros/mod-spdy)
 
-OpenSSL 1.0.1(h) and Apache 2.4.10 port for mod-ssl with npn support and mod-spdy. If you are looking for 2.4.7 (The version that is currently shipping with Ubuntu LTS, use the 2.4.7 branch)
+OpenSSL 1.0.1(j) and Apache 2.4.10 port for mod-ssl with npn support, TLS_FALLBACK_SCSV and mod-spdy. If you are looking for 2.4.7 (The version that is currently shipping with Ubuntu LTS, use the 2.4.7 branch)
 
 Status: Functional. Cleanup pending.
 
-apache2-2.4.10 + mod-ssl(npn,1.0.1h) + mod-spdy
+apache2-2.4.10 + mod-ssl(npn,1.0.1j) + mod-spdy
 
 
 Quick Start

--- a/src/build_modssl_with_npn.sh
+++ b/src/build_modssl_with_npn.sh
@@ -104,7 +104,7 @@ function uncompress_file {
   fi
 }
 
-OPENSSL_SRC_TGZ_URL="https://www.openssl.org/source/openssl-1.0.1h.tar.gz"
+OPENSSL_SRC_TGZ_URL="https://www.openssl.org/source/openssl-1.0.1j.tar.gz"
 APACHE_HTTPD_SRC_TGZ_URL="https://archive.apache.org/dist/httpd/httpd-2.4.10.tar.gz"
 APACHE_HTTPD_MODSSL_NPN_PATCH_PATH="$(dirname $0)/scripts/mod_ssl_with_npn.patch"
 
@@ -123,7 +123,7 @@ cp $APACHE_HTTPD_MODSSL_NPN_PATCH_PATH $BUILDROOT/$APACHE_HTTPD_MODSSL_NPN_PATCH
 
 pushd $BUILDROOT >/dev/null
 
-download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ 8d6d684a9430d5cc98a62a5d8fbda8cf
+download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ f7175c9cd3c39bb1907ac8bba9df8ed3
 download_file $APACHE_HTTPD_SRC_TGZ_URL $APACHE_HTTPD_SRC_TGZ 9b5f9342f73a6b1ad4e8c4b0f3f5a159
 
 echo ""


### PR DESCRIPTION
Patch confirmed working on CentOS 6.6 x86_64 with Apache 2.4.10, OpenSSL-1.0.1j and SPDY all functioning correctly. (Borked the branch)