### PR TITLE
Upgrade to Apache 2.4.12 and OpenSSL 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ mod-spdy
 
 [![Build Status](https://travis-ci.org/eousphoros/mod-spdy.svg?branch=master)](https://travis-ci.org/eousphoros/mod-spdy)
 
-OpenSSL 1.0.1(j) and Apache 2.4.10 port for mod-ssl with npn support, TLS_FALLBACK_SCSV and mod-spdy. If you are looking for 2.4.7 (The version that is currently shipping with Ubuntu LTS, use the 2.4.7 branch)
+OpenSSL 1.0.2 and Apache 2.4.12 port for mod-ssl with npn support, TLS_FALLBACK_SCSV and mod-spdy. If you are looking for 2.4.7 (The version that is currently shipping with Ubuntu LTS, use the 2.4.7 branch)
 
 Status: Functional. Cleanup pending.
 
-apache2-2.4.10 + mod-ssl(npn,1.0.1j) + mod-spdy
+apache2-2.4.12 + mod-ssl(npn,1.0.2) + mod-spdy
 
 
 Quick Start

--- a/src/build_modssl_with_npn.sh
+++ b/src/build_modssl_with_npn.sh
@@ -104,7 +104,7 @@ function uncompress_file {
   fi
 }
 
-OPENSSL_SRC_TGZ_URL="https://www.openssl.org/source/openssl-1.0.1j.tar.gz"
+OPENSSL_SRC_TGZ_URL="https://www.openssl.org/source/openssl-1.0.2.tar.gz"
 APACHE_HTTPD_SRC_TGZ_URL="https://archive.apache.org/dist/httpd/httpd-2.4.12.tar.gz"
 APACHE_HTTPD_MODSSL_NPN_PATCH_PATH="$(dirname $0)/scripts/mod_ssl_with_npn.patch"
 
@@ -123,7 +123,7 @@ cp $APACHE_HTTPD_MODSSL_NPN_PATCH_PATH $BUILDROOT/$APACHE_HTTPD_MODSSL_NPN_PATCH
 
 pushd $BUILDROOT >/dev/null
 
-download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ f7175c9cd3c39bb1907ac8bba9df8ed3
+download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ 38373013fc85c790aabf8837969c5eba
 download_file $APACHE_HTTPD_SRC_TGZ_URL $APACHE_HTTPD_SRC_TGZ ec8676a7fe62433883868b8341da6734
 
 echo ""

--- a/src/build_modssl_with_npn.sh
+++ b/src/build_modssl_with_npn.sh
@@ -105,7 +105,7 @@ function uncompress_file {
 }
 
 OPENSSL_SRC_TGZ_URL="https://www.openssl.org/source/openssl-1.0.1j.tar.gz"
-APACHE_HTTPD_SRC_TGZ_URL="https://archive.apache.org/dist/httpd/httpd-2.4.10.tar.gz"
+APACHE_HTTPD_SRC_TGZ_URL="https://archive.apache.org/dist/httpd/httpd-2.4.12.tar.gz"
 APACHE_HTTPD_MODSSL_NPN_PATCH_PATH="$(dirname $0)/scripts/mod_ssl_with_npn.patch"
 
 OPENSSL_SRC_TGZ=$(basename $OPENSSL_SRC_TGZ_URL)
@@ -124,7 +124,7 @@ cp $APACHE_HTTPD_MODSSL_NPN_PATCH_PATH $BUILDROOT/$APACHE_HTTPD_MODSSL_NPN_PATCH
 pushd $BUILDROOT >/dev/null
 
 download_file $OPENSSL_SRC_TGZ_URL $OPENSSL_SRC_TGZ f7175c9cd3c39bb1907ac8bba9df8ed3
-download_file $APACHE_HTTPD_SRC_TGZ_URL $APACHE_HTTPD_SRC_TGZ 9b5f9342f73a6b1ad4e8c4b0f3f5a159
+download_file $APACHE_HTTPD_SRC_TGZ_URL $APACHE_HTTPD_SRC_TGZ ec8676a7fe62433883868b8341da6734
 
 echo ""
 

--- a/src/third_party/apache/aprutil/src/CHANGES
+++ b/src/third_party/apache/aprutil/src/CHANGES
@@ -1,4 +1,30 @@
                                                      -*- coding: utf-8 -*-
+Changes with APR-util 1.5.4
+
+  *) MySQL driver: Fix incorrect handling of bad parameter in the
+     driver support for apr_dbd_transaction_end().  PR 56330.
+     [Weiqiang Li <weiqiang_li hotmail.com>]
+
+  *) apr_crypto_get_driver(): Fix invalid storage reference on error path.
+     [Philip Martin <philip.martin wandisco.com>]
+
+  *) Fix compile failure for Android.  PR 56627.  [Fredrik Fornwall 
+     <fredrik fornwall.net>, Jeff Trawick]
+
+  *) Fix to let ODBC driver build with MSVC6, which does not have intptr_t
+     [Tom Donovan]
+
+  *) Windows cmake build: Fix incompatiblities with Visual Studio
+     generators with all cmake versions, and the NMake Makefile generator
+     with cmake 2.8.12 and later.  PR 56616 and other bugs.  [Jeff Trawick,
+     Bert Huijben]
+
+  *) Fix detection of Berkeley DB 6.0. PR 55277.
+     [Lars Wendler <polynomial-c gentoo.org>]
+
+  *) Improve platform detection for bundled expat by updating
+     config.guess and config.sub. [Rainer Jung]
+
 Changes with APR-util 1.5.3
 
   *) Cygwin: Use correct file extension when loading APR DSOs.  PR 55587.

--- a/src/third_party/apache/aprutil/src/CMakeLists.txt
+++ b/src/third_party/apache/aprutil/src/CMakeLists.txt
@@ -218,8 +218,9 @@ SET(EXPAT_SOURCES
 
 SET(install_targets)
 SET(install_bin_pdb)
-SET(install_lib_pdb)
 SET(dbd_drivers)
+
+# Note: The WINNT definition on some targets is used only by libaprutil.rc.
 
 # static expat (not installed)
 ADD_LIBRARY(libexpat STATIC ${EXPAT_SOURCES})
@@ -230,11 +231,10 @@ ADD_LIBRARY(libaprutil-1 SHARED ${APR_SOURCES} ${APR_PUBLIC_HEADERS_GENERATED} l
 SET(install_targets ${install_targets} libaprutil-1)
 SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/libaprutil-1.pdb)
 TARGET_LINK_LIBRARIES(libaprutil-1 ${APR_LIBRARIES} ${XMLLIB_LIBRARIES})
-SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;XML_STATIC")
+SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;XML_STATIC;WINNT")
 
 ADD_LIBRARY(aprutil-1 STATIC ${APR_SOURCES} ${APR_PUBLIC_HEADERS_GENERATED})
 SET(install_targets ${install_targets} aprutil-1)
-SET(install_lib_pdb ${install_lib_pdb} ${PROJECT_BINARY_DIR}/aprutil-1.pdb)
 TARGET_LINK_LIBRARIES(aprutil-1 ${APR_LIBRARIES} ${XMLLIB_LIBRARIES})
 SET_TARGET_PROPERTIES(aprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_STATIC;APR_DECLARE_STATIC;APU_DSO_MODULE_BUILD;XML_STATIC")
 
@@ -246,7 +246,8 @@ IF(APU_HAVE_CRYPTO)
   SET(install_targets ${install_targets} apr_crypto_openssl-1)
   SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/apr_crypto_openssl-1.pdb)
   SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES INCLUDE_DIRECTORIES "${APR_INCLUDE_DIRECTORIES};${OPENSSL_INCLUDE_DIR}")
-  SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_FLAGS "-DDLL_NAME=\"\\\"apr_crypto_openssl\\\"\"")
+  SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_DEFINITIONS "WINNT")
+  SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_FLAGS "-DDLL_NAME=apr_crypto_openssl")
   TARGET_LINK_LIBRARIES(apr_crypto_openssl-1 libaprutil-1 ${APR_LIBRARIES} ${OPENSSL_LIBRARIES})
 ENDIF()
 
@@ -257,8 +258,8 @@ IF(APU_HAVE_ODBC)
   SET(dbd_drivers ${dbd_drivers} odbc)
   TARGET_LINK_LIBRARIES(apr_dbd_odbc-1 libaprutil-1 ${APR_LIBRARIES} odbc32 odbccp32)
   SET_PROPERTY(TARGET apr_dbd_odbc-1 APPEND PROPERTY LINK_FLAGS /export:apr_dbd_odbc_driver)
-  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_DEFINITIONS "APU_HAVE_ODBC;HAVE_SQL_H;APU_DECLARE_EXPORT;APU_DSO_MODULE_BUILD")
-  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_FLAGS "-DDLL_NAME=\"\\\"apr_dbd_odbc\\\"\"")
+  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_DEFINITIONS "APU_HAVE_ODBC;HAVE_SQL_H;APU_DECLARE_EXPORT;APU_DSO_MODULE_BUILD;WINNT")
+  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_FLAGS "-DDLL_NAME=apr_dbd_odbc")
 ENDIF()
 
 IF(APR_HAS_LDAP)
@@ -267,7 +268,8 @@ IF(APR_HAS_LDAP)
   SET(install_targets ${install_targets} apr_ldap-1)
   SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/apr_ldap-1.pdb)
   TARGET_LINK_LIBRARIES(apr_ldap-1 libaprutil-1 ${APR_LIBRARIES} ${LDAP_LIBRARIES})
-  SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_FLAGS "-DDLL_NAME=\"\\\"apr_ldap\\\"\"")
+  SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_DEFINITIONS "WINNT")
+  SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_FLAGS "-DDLL_NAME=apr_ldap")
   SET(apr_ldap_libraries apr_ldap-1)
 ELSE()
   SET(apr_ldap_libraries)
@@ -324,10 +326,6 @@ INSTALL(TARGETS ${install_targets}
 IF(INSTALL_PDB)
   INSTALL(FILES ${install_bin_pdb}
           DESTINATION bin
-          CONFIGURATIONS RelWithDebInfo Debug)
-
-  INSTALL(FILES ${install_lib_pdb}
-          DESTINATION lib
           CONFIGURATIONS RelWithDebInfo Debug)
 ENDIF()
 

--- a/src/third_party/apache/aprutil/src/NOTICE
+++ b/src/third_party/apache/aprutil/src/NOTICE
@@ -1,7 +1,7 @@
 Apache Portable Runtime Utility Library
-Copyright (c) 2011 The Apache Software Foundation.
+Copyright (c) 2000-2014 The Apache Software Foundation.
 
-This product includes software developed by
+This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 Portions of this software were developed at the National Center

--- a/src/third_party/apache/aprutil/src/README.cmake
+++ b/src/third_party/apache/aprutil/src/README.cmake
@@ -4,6 +4,8 @@ Status
 ------
 
 This build support is currently intended only for Microsoft Windows.
+Only Windows NT-based systems can be targeted.  (The traditional 
+Windows build support for APR can target Windows 9x as well.)
 
 This build support is experimental.  Specifically,
 

--- a/src/third_party/apache/aprutil/src/apr-util.spec
+++ b/src/third_party/apache/aprutil/src/apr-util.spec
@@ -3,7 +3,7 @@
 
 Summary: Apache Portable Runtime Utility library
 Name: apr-util
-Version: 1.5.3
+Version: 1.5.4
 Release: 1
 License: Apache Software License
 Group: System Environment/Libraries

--- a/src/third_party/apache/aprutil/src/build/config.guess
+++ b/src/third_party/apache/aprutil/src/build/config.guess
@@ -1,8 +1,8 @@
 #! /bin/sh
 # Attempt to guess a canonical system name.
-#   Copyright 1992-2013 Free Software Foundation, Inc.
+#   Copyright 1992-2014 Free Software Foundation, Inc.
 
-timestamp='2013-06-10'
+timestamp='2014-02-12'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -50,7 +50,7 @@ version="\
 GNU config.guess ($timestamp)
 
 Originally written by Per Bothner.
-Copyright 1992-2013 Free Software Foundation, Inc.
+Copyright 1992-2014 Free Software Foundation, Inc.
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
@@ -149,7 +149,7 @@ Linux|GNU|GNU/*)
 	LIBC=gnu
 	#endif
 	EOF
-	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^LIBC'`
+	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`
 	;;
 esac
 
@@ -1260,16 +1260,26 @@ EOF
 	if test "$UNAME_PROCESSOR" = unknown ; then
 	    UNAME_PROCESSOR=powerpc
 	fi
-	if [ "$CC_FOR_BUILD" != 'no_compiler_found' ]; then
-	    if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
-		(CCOPTS= $CC_FOR_BUILD -E - 2>/dev/null) | \
-		grep IS_64BIT_ARCH >/dev/null
-	    then
-		case $UNAME_PROCESSOR in
-		    i386) UNAME_PROCESSOR=x86_64 ;;
-		    powerpc) UNAME_PROCESSOR=powerpc64 ;;
-		esac
+	if test `echo "$UNAME_RELEASE" | sed -e 's/\..*//'` -le 10 ; then
+	    if [ "$CC_FOR_BUILD" != 'no_compiler_found' ]; then
+		if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
+		    (CCOPTS= $CC_FOR_BUILD -E - 2>/dev/null) | \
+		    grep IS_64BIT_ARCH >/dev/null
+		then
+		    case $UNAME_PROCESSOR in
+			i386) UNAME_PROCESSOR=x86_64 ;;
+			powerpc) UNAME_PROCESSOR=powerpc64 ;;
+		    esac
+		fi
 	    fi
+	elif test "$UNAME_PROCESSOR" = i386 ; then
+	    # Avoid executing cc on OS X 10.9, as it ships with a stub
+	    # that puts up a graphical alert prompting to install
+	    # developer tools.  Any system running Mac OS X 10.7 or
+	    # later (Darwin 11 and later) is required to have a 64-bit
+	    # processor. This is not true of the ARM version of Darwin
+	    # that Apple uses in portable devices.
+	    UNAME_PROCESSOR=x86_64
 	fi
 	echo ${UNAME_PROCESSOR}-apple-darwin${UNAME_RELEASE}
 	exit ;;
@@ -1360,154 +1370,6 @@ EOF
 	echo ${UNAME_MACHINE}-unknown-esx
 	exit ;;
 esac
-
-eval $set_cc_for_build
-cat >$dummy.c <<EOF
-#ifdef _SEQUENT_
-# include <sys/types.h>
-# include <sys/utsname.h>
-#endif
-main ()
-{
-#if defined (sony)
-#if defined (MIPSEB)
-  /* BFD wants "bsd" instead of "newsos".  Perhaps BFD should be changed,
-     I don't know....  */
-  printf ("mips-sony-bsd\n"); exit (0);
-#else
-#include <sys/param.h>
-  printf ("m68k-sony-newsos%s\n",
-#ifdef NEWSOS4
-	"4"
-#else
-	""
-#endif
-	); exit (0);
-#endif
-#endif
-
-#if defined (__arm) && defined (__acorn) && defined (__unix)
-  printf ("arm-acorn-riscix\n"); exit (0);
-#endif
-
-#if defined (hp300) && !defined (hpux)
-  printf ("m68k-hp-bsd\n"); exit (0);
-#endif
-
-#if defined (NeXT)
-#if !defined (__ARCHITECTURE__)
-#define __ARCHITECTURE__ "m68k"
-#endif
-  int version;
-  version=`(hostinfo | sed -n 's/.*NeXT Mach \([0-9]*\).*/\1/p') 2>/dev/null`;
-  if (version < 4)
-    printf ("%s-next-nextstep%d\n", __ARCHITECTURE__, version);
-  else
-    printf ("%s-next-openstep%d\n", __ARCHITECTURE__, version);
-  exit (0);
-#endif
-
-#if defined (MULTIMAX) || defined (n16)
-#if defined (UMAXV)
-  printf ("ns32k-encore-sysv\n"); exit (0);
-#else
-#if defined (CMU)
-  printf ("ns32k-encore-mach\n"); exit (0);
-#else
-  printf ("ns32k-encore-bsd\n"); exit (0);
-#endif
-#endif
-#endif
-
-#if defined (__386BSD__)
-  printf ("i386-pc-bsd\n"); exit (0);
-#endif
-
-#if defined (sequent)
-#if defined (i386)
-  printf ("i386-sequent-dynix\n"); exit (0);
-#endif
-#if defined (ns32000)
-  printf ("ns32k-sequent-dynix\n"); exit (0);
-#endif
-#endif
-
-#if defined (_SEQUENT_)
-    struct utsname un;
-
-    uname(&un);
-
-    if (strncmp(un.version, "V2", 2) == 0) {
-	printf ("i386-sequent-ptx2\n"); exit (0);
-    }
-    if (strncmp(un.version, "V1", 2) == 0) { /* XXX is V1 correct? */
-	printf ("i386-sequent-ptx1\n"); exit (0);
-    }
-    printf ("i386-sequent-ptx\n"); exit (0);
-
-#endif
-
-#if defined (vax)
-# if !defined (ultrix)
-#  include <sys/param.h>
-#  if defined (BSD)
-#   if BSD == 43
-      printf ("vax-dec-bsd4.3\n"); exit (0);
-#   else
-#    if BSD == 199006
-      printf ("vax-dec-bsd4.3reno\n"); exit (0);
-#    else
-      printf ("vax-dec-bsd\n"); exit (0);
-#    endif
-#   endif
-#  else
-    printf ("vax-dec-bsd\n"); exit (0);
-#  endif
-# else
-    printf ("vax-dec-ultrix\n"); exit (0);
-# endif
-#endif
-
-#if defined (alliant) && defined (i860)
-  printf ("i860-alliant-bsd\n"); exit (0);
-#endif
-
-  exit (1);
-}
-EOF
-
-$CC_FOR_BUILD -o $dummy $dummy.c 2>/dev/null && SYSTEM_NAME=`$dummy` &&
-	{ echo "$SYSTEM_NAME"; exit; }
-
-# Apollos put the system type in the environment.
-
-test -d /usr/apollo && { echo ${ISP}-apollo-${SYSTYPE}; exit; }
-
-# Convex versions that predate uname can use getsysinfo(1)
-
-if [ -x /usr/convex/getsysinfo ]
-then
-    case `getsysinfo -f cpu_type` in
-    c1*)
-	echo c1-convex-bsd
-	exit ;;
-    c2*)
-	if getsysinfo -f scalar_acc
-	then echo c32-convex-bsd
-	else echo c2-convex-bsd
-	fi
-	exit ;;
-    c34*)
-	echo c34-convex-bsd
-	exit ;;
-    c38*)
-	echo c38-convex-bsd
-	exit ;;
-    c4*)
-	echo c4-convex-bsd
-	exit ;;
-    esac
-fi
 
 cat >&2 <<EOF
 $0: unable to guess system type

--- a/src/third_party/apache/aprutil/src/build/config.sub
+++ b/src/third_party/apache/aprutil/src/build/config.sub
@@ -1,8 +1,8 @@
 #! /bin/sh
 # Configuration validation subroutine script.
-#   Copyright 1992-2013 Free Software Foundation, Inc.
+#   Copyright 1992-2014 Free Software Foundation, Inc.
 
-timestamp='2013-10-01'
+timestamp='2014-01-01'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -68,7 +68,7 @@ Report bugs and patches to <config-patches@gnu.org>."
 version="\
 GNU config.sub ($timestamp)
 
-Copyright 1992-2013 Free Software Foundation, Inc.
+Copyright 1992-2014 Free Software Foundation, Inc.
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."

--- a/src/third_party/apache/aprutil/src/build/dbm.m4
+++ b/src/third_party/apache/aprutil/src/build/dbm.m4
@@ -112,7 +112,7 @@ AC_DEFUN([APU_CHECK_BERKELEY_DB], [
         changequote([,])
         unset $cache_id
         AC_CHECK_HEADER([$bdb_header], [
-          if test "$1" = "3" -o "$1" = "4" -o "$1" = "5"; then
+          if test "$1" = "3" -o "$1" = "4" -o "$1" = "5" -o "$1" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -455,13 +455,13 @@ AC_DEFUN([APU_CHECK_DB], [
 ])
 
 dnl
-dnl APU_CHECK_DB_ALL: Try all Berkeley DB versions, from 5.X to 1.
+dnl APU_CHECK_DB_ALL: Try all Berkeley DB versions, from 6.X to 1.
 dnl
 AC_DEFUN([APU_CHECK_DB_ALL], [
   all_places=$1
 
-  # Start version search at version 5.9
-  db_version=59
+  # Start version search at version 6.9
+  db_version=69
   while [[ $db_version -ge 40 ]]
   do
     db_major=`echo $db_version | sed -e 's/.$//'`
@@ -511,19 +511,34 @@ AC_DEFUN([APU_CHECK_DBM], [
   apu_db_version=0
 
   # Maximum supported version announced in help string.
-  # Although we search for all versions up to 5.9,
+  # Although we search for all versions up to 6.9,
   # we should only include existing versions in our
   # help string.
-  db_max_version=53
-  db_min_version=41
   dbm_list="sdbm, gdbm, ndbm, db, db1, db185, db2, db3, db4"
+  db_max_version=48
+  db_min_version=41
   db_version="$db_min_version"
   while [[ $db_version -le $db_max_version ]]
   do
     dbm_list="$dbm_list, db$db_version"
     db_version=`expr $db_version + 1`
   done
-  dbm_list="$dbm_list, db60"
+  db_max_version=53
+  db_min_version=50
+  db_version="$db_min_version"
+  while [[ $db_version -le $db_max_version ]]
+  do
+    dbm_list="$dbm_list, db$db_version"
+    db_version=`expr $db_version + 1`
+  done
+  db_max_version=60
+  db_min_version=60
+  db_version="$db_min_version"
+  while [[ $db_version -le $db_max_version ]]
+  do
+    dbm_list="$dbm_list, db$db_version"
+    db_version=`expr $db_version + 1`
+  done
 
   AC_ARG_WITH(dbm, [APR_HELP_STRING([--with-dbm=DBM], [choose the DBM type to use.
       DBM={sdbm,gdbm,ndbm,db,db1,db185,db2,db3,db4,db4X,db5X,db6X} for some X=0,...,9])],

--- a/src/third_party/apache/aprutil/src/configure
+++ b/src/third_party/apache/aprutil/src/configure
@@ -11608,19 +11608,34 @@ fi
   apu_db_version=0
 
   # Maximum supported version announced in help string.
-  # Although we search for all versions up to 5.9,
+  # Although we search for all versions up to 6.9,
   # we should only include existing versions in our
   # help string.
-  db_max_version=53
-  db_min_version=41
   dbm_list="sdbm, gdbm, ndbm, db, db1, db185, db2, db3, db4"
+  db_max_version=48
+  db_min_version=41
   db_version="$db_min_version"
   while [ $db_version -le $db_max_version ]
   do
     dbm_list="$dbm_list, db$db_version"
     db_version=`expr $db_version + 1`
   done
-  dbm_list="$dbm_list, db60"
+  db_max_version=53
+  db_min_version=50
+  db_version="$db_min_version"
+  while [ $db_version -le $db_max_version ]
+  do
+    dbm_list="$dbm_list, db$db_version"
+    db_version=`expr $db_version + 1`
+  done
+  db_max_version=60
+  db_min_version=60
+  db_version="$db_min_version"
+  while [ $db_version -le $db_max_version ]
+  do
+    dbm_list="$dbm_list, db$db_version"
+    db_version=`expr $db_version + 1`
+  done
 
 
 # Check whether --with-dbm was given.
@@ -12093,8 +12108,8 @@ if test "${with_berkeley_db+set}" = set; then :
 
   all_places="$check_places"
 
-  # Start version search at version 5.9
-  db_version=59
+  # Start version search at version 6.9
+  db_version=69
   while [ $db_version -ge 40 ]
   do
     db_major=`echo $db_version | sed -e 's/.$//'`
@@ -12178,7 +12193,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5"; then
+          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5" -o ""${db_major}"" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -12580,7 +12595,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "3" = "3" -o "3" = "4" -o "3" = "5"; then
+          if test "3" = "3" -o "3" = "4" -o "3" = "5" -o "3" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -12978,7 +12993,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "2" = "3" -o "2" = "4" -o "2" = "5"; then
+          if test "2" = "3" -o "2" = "4" -o "2" = "5" -o "2" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -13376,7 +13391,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "1" = "3" -o "1" = "4" -o "1" = "5"; then
+          if test "1" = "3" -o "1" = "4" -o "1" = "5" -o "1" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -13774,7 +13789,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "1" = "3" -o "1" = "4" -o "1" = "5"; then
+          if test "1" = "3" -o "1" = "4" -o "1" = "5" -o "1" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -14186,7 +14201,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "1" = "3" -o "1" = "4" -o "1" = "5"; then
+          if test "1" = "3" -o "1" = "4" -o "1" = "5" -o "1" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -14587,7 +14602,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "1" = "3" -o "1" = "4" -o "1" = "5"; then
+          if test "1" = "3" -o "1" = "4" -o "1" = "5" -o "1" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -14988,7 +15003,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "2" = "3" -o "2" = "4" -o "2" = "5"; then
+          if test "2" = "3" -o "2" = "4" -o "2" = "5" -o "2" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -15389,7 +15404,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "3" = "3" -o "3" = "4" -o "3" = "5"; then
+          if test "3" = "3" -o "3" = "4" -o "3" = "5" -o "3" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -15794,7 +15809,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5"; then
+          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5" -o ""${db_major}"" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -16202,7 +16217,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5"; then
+          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5" -o ""${db_major}"" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -16534,8 +16549,8 @@ fi
 
   all_places="$check_places"
 
-  # Start version search at version 5.9
-  db_version=59
+  # Start version search at version 6.9
+  db_version=69
   while [ $db_version -ge 40 ]
   do
     db_major=`echo $db_version | sed -e 's/.$//'`
@@ -16619,7 +16634,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5"; then
+          if test ""${db_major}"" = "3" -o ""${db_major}"" = "4" -o ""${db_major}"" = "5" -o ""${db_major}"" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -17021,7 +17036,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "3" = "3" -o "3" = "4" -o "3" = "5"; then
+          if test "3" = "3" -o "3" = "4" -o "3" = "5" -o "3" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -17419,7 +17434,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "2" = "3" -o "2" = "4" -o "2" = "5"; then
+          if test "2" = "3" -o "2" = "4" -o "2" = "5" -o "2" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -17817,7 +17832,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "1" = "3" -o "1" = "4" -o "1" = "5"; then
+          if test "1" = "3" -o "1" = "4" -o "1" = "5" -o "1" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of
@@ -18215,7 +18230,7 @@ $as_echo "" >&6; }
 ac_fn_c_check_header_mongrel "$LINENO" "$bdb_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
-          if test "1" = "3" -o "1" = "4" -o "1" = "5"; then
+          if test "1" = "3" -o "1" = "4" -o "1" = "5" -o "1" = "6"; then
             # We generate a separate cache variable for each prefix and libname
             # we search under.  That way, we avoid caching information that
             # changes if the user runs `configure' with a different set of

--- a/src/third_party/apache/aprutil/src/crypto/apr_crypto.c
+++ b/src/third_party/apache/aprutil/src/crypto/apr_crypto.c
@@ -204,7 +204,7 @@ APU_DECLARE(apr_status_t) apr_crypto_get_driver(
         if (err && buffer) {
             apr_dso_error(dso, buffer, ERROR_SIZE - 1);
             err->msg = buffer;
-            err->reason = modname;
+            err->reason = apr_pstrdup(pool, modname);
             *result = err;
         }
     }

--- a/src/third_party/apache/aprutil/src/crypto/apr_passwd.c
+++ b/src/third_party/apache/aprutil/src/crypto/apr_passwd.c
@@ -66,6 +66,12 @@ static void crypt_mutex_unlock(void)
 #endif
 #endif
 
+#if defined(WIN32) || defined(BEOS) || defined(NETWARE) || defined(__ANDROID__)
+#define CRYPT_MISSING 1
+#else
+#define CRYPT_MISSING 0
+#endif
+
 /*
  * Validate a plaintext password against a smashed one.  Uses either
  * crypt() (if available) or apr_md5_encode() or apr_sha1_base64(), depending
@@ -77,7 +83,7 @@ APU_DECLARE(apr_status_t) apr_password_validate(const char *passwd,
                                                 const char *hash)
 {
     char sample[200];
-#if !defined(WIN32) && !defined(BEOS) && !defined(NETWARE)
+#if !CRYPT_MISSING
     char *crypt_pw;
 #endif
     if (hash[0] == '$'
@@ -100,7 +106,7 @@ APU_DECLARE(apr_status_t) apr_password_validate(const char *passwd,
         /*
          * It's not our algorithm, so feed it to crypt() if possible.
          */
-#if defined(WIN32) || defined(BEOS) || defined(NETWARE)
+#if CRYPT_MISSING
         return (strcmp(passwd, hash) == 0) ? APR_SUCCESS : APR_EMISMATCH;
 #elif defined(CRYPT_R_CRYPTD)
         apr_status_t rv;

--- a/src/third_party/apache/aprutil/src/dbd/apr_dbd_mysql.c
+++ b/src/third_party/apache/aprutil/src/dbd/apr_dbd_mysql.c
@@ -1050,9 +1050,9 @@ static int dbd_mysql_end_transaction(apr_dbd_transaction_t *trans)
         else {
             ret = mysql_commit(trans->handle->conn);
         }
+        ret |= mysql_autocommit(trans->handle->conn, 1);
+        trans->handle->trans = NULL;
     }
-    ret |= mysql_autocommit(trans->handle->conn, 1);
-    trans->handle->trans = NULL;
     return ret;
 }
 /* Whether or not transactions work depends on whether the

--- a/src/third_party/apache/aprutil/src/dbd/apr_dbd_odbc.c
+++ b/src/third_party/apache/aprutil/src/dbd/apr_dbd_odbc.c
@@ -47,6 +47,21 @@
 #include <odbc/sqlext.h>
 #endif
 
+/*
+* MSVC6 does not support intptr_t (C99)
+* APR does not have a signed inptr type until 2.0  (r1557720)
+*/
+#if defined(_MSC_VER) && _MSC_VER < 1400
+#if APR_SIZEOF_VOIDP == 8
+#define   ODBC_INTPTR_T  apr_int64_t
+#else
+#define   ODBC_INTPTR_T  apr_int32_t
+#endif
+#else
+#define   ODBC_INTPTR_T  intptr_t
+#endif
+
+
 /* Driver name is "odbc" and the entry point is 'apr_dbd_odbc_driver' 
  * unless ODBC_DRIVER_NAME is defined and it is linked with another db library which
  * is ODBC source-compatible. e.g. DB2, Informix, TimesTen, mysql.  
@@ -114,9 +129,9 @@ struct apr_dbd_t
     char lastError[MAX_ERROR_STRING];
     int defaultBufferSize;      /* used for CLOBs in text mode, 
                                  * and when fld size is indeterminate */
-    intptr_t transaction_mode;
-    intptr_t dboptions;         /* driver options re SQLGetData */
-    intptr_t default_transaction_mode;
+    ODBC_INTPTR_T transaction_mode;
+    ODBC_INTPTR_T dboptions;         /* driver options re SQLGetData */
+    ODBC_INTPTR_T default_transaction_mode;
     int can_commit;             /* controls end_trans behavior */
 };
 
@@ -359,7 +374,7 @@ static SQLRETURN odbc_set_result_column(int icol, apr_dbd_results_t *res,
                                         SQLHANDLE stmt)
 {
     SQLRETURN rc;
-    intptr_t maxsize, textsize, realsize, type, isunsigned = 1;
+    ODBC_INTPTR_T maxsize, textsize, realsize, type, isunsigned = 1;
 
     /* discover the sql type */
     rc = SQLColAttribute(stmt, icol + 1, SQL_DESC_UNSIGNED, NULL, 0, NULL,
@@ -747,7 +762,7 @@ static void *odbc_get(const apr_dbd_row_t *row, const int col,
     SQLRETURN rc;
     SQLLEN indicator;
     int state = row->res->colstate[col];
-    intptr_t options = row->res->apr_dbd->dboptions;
+    ODBC_INTPTR_T options = row->res->apr_dbd->dboptions;
 
     switch (state) {
     case (COL_UNAVAIL):
@@ -817,13 +832,13 @@ static apr_status_t odbc_parse_params(apr_pool_t *pool, const char *params,
                                int *connect, SQLCHAR **datasource, 
                                SQLCHAR **user, SQLCHAR **password, 
                                int *defaultBufferSize, int *nattrs,
-                               int **attrs, intptr_t **attrvals)
+                               int **attrs, ODBC_INTPTR_T **attrvals)
 {
     char *seps, *last, *next, *name[MAX_PARAMS], *val[MAX_PARAMS];
     int nparams = 0, i, j;
 
     *attrs = apr_pcalloc(pool, MAX_PARAMS * sizeof(char *));
-    *attrvals = apr_pcalloc(pool, MAX_PARAMS * sizeof(intptr_t));
+    *attrvals = apr_pcalloc(pool, MAX_PARAMS * sizeof(ODBC_INTPTR_T));
     *nattrs = 0;
     seps = DEFAULTSEPS;
     name[nparams] = apr_strtok(apr_pstrdup(pool, params), seps, &last);
@@ -1063,7 +1078,7 @@ static apr_dbd_t *odbc_open(apr_pool_t *pool, const char *params, const char **e
     SQLCHAR  *datasource = (SQLCHAR *)"", *user = (SQLCHAR *)"",
              *password = (SQLCHAR *)"";
     int nattrs = 0, *attrs = NULL,  connect = 0;
-    intptr_t *attrvals = NULL;
+    ODBC_INTPTR_T *attrvals = NULL;
 
     err_step = "SQLAllocHandle (SQL_HANDLE_DBC)";
     err_htype = SQL_HANDLE_ENV;
@@ -1117,10 +1132,10 @@ static apr_dbd_t *odbc_open(apr_pool_t *pool, const char *params, const char **e
         handle->default_transaction_mode = 0;
         handle->can_commit = APR_DBD_TRANSACTION_IGNORE_ERRORS;
         SQLGetInfo(hdbc, SQL_DEFAULT_TXN_ISOLATION,
-                   &(handle->default_transaction_mode), sizeof(intptr_t), NULL);
+                   &(handle->default_transaction_mode), sizeof(ODBC_INTPTR_T), NULL);
         handle->transaction_mode = handle->default_transaction_mode;
         SQLGetInfo(hdbc, SQL_GETDATA_EXTENSIONS ,&(handle->dboptions),
-                   sizeof(intptr_t), NULL);
+                   sizeof(ODBC_INTPTR_T), NULL);
         apr_pool_cleanup_register(pool, handle, odbc_close_cleanup, apr_pool_cleanup_null);
         return handle;
     }

--- a/src/third_party/apache/aprutil/src/dbm/NWGNUmakefile
+++ b/src/third_party/apache/aprutil/src/dbm/NWGNUmakefile
@@ -235,7 +235,7 @@ nlms :: libs $(TARGET_nlm)
 # correct place.  (See $(AP_WORK)\build\NWGNUhead.inc for examples)
 #
 install :: nlms $(INSTDIRS) FORCE
-	copy $(OBJDIR)\*.nlm $(INSTALLBASE)
+	$(call COPY,$(OBJDIR)/*.nlm,$(INSTALLBASE))
 
 #
 # Any specialized rules here

--- a/src/third_party/apache/aprutil/src/include/apu_version.h
+++ b/src/third_party/apache/aprutil/src/include/apu_version.h
@@ -38,7 +38,7 @@
  */
 
 
-#define APU_COPYRIGHT "Copyright (c) 2013 The Apache Software " \
+#define APU_COPYRIGHT "Copyright (c) 2000-2014 The Apache Software " \
                       "Foundation or its licensors, as applicable."
 
 /* The numeric compile-time version constants. These constants are the
@@ -62,7 +62,7 @@
  * The Patch Level never includes API changes, simply bug fixes.
  * Reset to 0 when upgrading APR_MINOR_VERSION
  */
-#define APU_PATCH_VERSION       3
+#define APU_PATCH_VERSION       4
 
 /** 
  * The symbol APU_IS_DEV_VERSION is only defined for internal,

--- a/src/third_party/apache/aprutil/src/test/Makefile.win
+++ b/src/third_party/apache/aprutil/src/test/Makefile.win
@@ -88,6 +88,8 @@ APROUTDIR=$(OUTDIR)
 !IF "$(MODEL)" == "static"
 PROGRAM_DEPENDENCIES = \
 	$(APR_PATH)\$(APROUTDIR)\apr-1.lib \
+	$(API_PATH)\$(OUTDIR)\apriconv-1.lib \
+	..\xml\expat\lib\$(OUTDIR)\xml.lib \
 	..\$(OUTDIR)\aprutil-1.lib 
 STATIC_CFLAGS = /D APR_DECLARE_STATIC /D APU_DECLARE_STATIC
 STATIC_LIBS = odbc32.lib odbccp32.lib wldap32.lib 

--- a/src/third_party/apache/aprutil/src/xml/expat/conftools/config.guess
+++ b/src/third_party/apache/aprutil/src/xml/expat/conftools/config.guess
@@ -1,8 +1,8 @@
 #! /bin/sh
 # Attempt to guess a canonical system name.
-#   Copyright 1992-2013 Free Software Foundation, Inc.
+#   Copyright 1992-2014 Free Software Foundation, Inc.
 
-timestamp='2013-06-10'
+timestamp='2014-02-12'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -50,7 +50,7 @@ version="\
 GNU config.guess ($timestamp)
 
 Originally written by Per Bothner.
-Copyright 1992-2013 Free Software Foundation, Inc.
+Copyright 1992-2014 Free Software Foundation, Inc.
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
@@ -149,7 +149,7 @@ Linux|GNU|GNU/*)
 	LIBC=gnu
 	#endif
 	EOF
-	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^LIBC'`
+	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`
 	;;
 esac
 
@@ -1260,16 +1260,26 @@ EOF
 	if test "$UNAME_PROCESSOR" = unknown ; then
 	    UNAME_PROCESSOR=powerpc
 	fi
-	if [ "$CC_FOR_BUILD" != 'no_compiler_found' ]; then
-	    if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
-		(CCOPTS= $CC_FOR_BUILD -E - 2>/dev/null) | \
-		grep IS_64BIT_ARCH >/dev/null
-	    then
-		case $UNAME_PROCESSOR in
-		    i386) UNAME_PROCESSOR=x86_64 ;;
-		    powerpc) UNAME_PROCESSOR=powerpc64 ;;
-		esac
+	if test `echo "$UNAME_RELEASE" | sed -e 's/\..*//'` -le 10 ; then
+	    if [ "$CC_FOR_BUILD" != 'no_compiler_found' ]; then
+		if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
+		    (CCOPTS= $CC_FOR_BUILD -E - 2>/dev/null) | \
+		    grep IS_64BIT_ARCH >/dev/null
+		then
+		    case $UNAME_PROCESSOR in
+			i386) UNAME_PROCESSOR=x86_64 ;;
+			powerpc) UNAME_PROCESSOR=powerpc64 ;;
+		    esac
+		fi
 	    fi
+	elif test "$UNAME_PROCESSOR" = i386 ; then
+	    # Avoid executing cc on OS X 10.9, as it ships with a stub
+	    # that puts up a graphical alert prompting to install
+	    # developer tools.  Any system running Mac OS X 10.7 or
+	    # later (Darwin 11 and later) is required to have a 64-bit
+	    # processor. This is not true of the ARM version of Darwin
+	    # that Apple uses in portable devices.
+	    UNAME_PROCESSOR=x86_64
 	fi
 	echo ${UNAME_PROCESSOR}-apple-darwin${UNAME_RELEASE}
 	exit ;;
@@ -1360,154 +1370,6 @@ EOF
 	echo ${UNAME_MACHINE}-unknown-esx
 	exit ;;
 esac
-
-eval $set_cc_for_build
-cat >$dummy.c <<EOF
-#ifdef _SEQUENT_
-# include <sys/types.h>
-# include <sys/utsname.h>
-#endif
-main ()
-{
-#if defined (sony)
-#if defined (MIPSEB)
-  /* BFD wants "bsd" instead of "newsos".  Perhaps BFD should be changed,
-     I don't know....  */
-  printf ("mips-sony-bsd\n"); exit (0);
-#else
-#include <sys/param.h>
-  printf ("m68k-sony-newsos%s\n",
-#ifdef NEWSOS4
-	"4"
-#else
-	""
-#endif
-	); exit (0);
-#endif
-#endif
-
-#if defined (__arm) && defined (__acorn) && defined (__unix)
-  printf ("arm-acorn-riscix\n"); exit (0);
-#endif
-
-#if defined (hp300) && !defined (hpux)
-  printf ("m68k-hp-bsd\n"); exit (0);
-#endif
-
-#if defined (NeXT)
-#if !defined (__ARCHITECTURE__)
-#define __ARCHITECTURE__ "m68k"
-#endif
-  int version;
-  version=`(hostinfo | sed -n 's/.*NeXT Mach \([0-9]*\).*/\1/p') 2>/dev/null`;
-  if (version < 4)
-    printf ("%s-next-nextstep%d\n", __ARCHITECTURE__, version);
-  else
-    printf ("%s-next-openstep%d\n", __ARCHITECTURE__, version);
-  exit (0);
-#endif
-
-#if defined (MULTIMAX) || defined (n16)
-#if defined (UMAXV)
-  printf ("ns32k-encore-sysv\n"); exit (0);
-#else
-#if defined (CMU)
-  printf ("ns32k-encore-mach\n"); exit (0);
-#else
-  printf ("ns32k-encore-bsd\n"); exit (0);
-#endif
-#endif
-#endif
-
-#if defined (__386BSD__)
-  printf ("i386-pc-bsd\n"); exit (0);
-#endif
-
-#if defined (sequent)
-#if defined (i386)
-  printf ("i386-sequent-dynix\n"); exit (0);
-#endif
-#if defined (ns32000)
-  printf ("ns32k-sequent-dynix\n"); exit (0);
-#endif
-#endif
-
-#if defined (_SEQUENT_)
-    struct utsname un;
-
-    uname(&un);
-
-    if (strncmp(un.version, "V2", 2) == 0) {
-	printf ("i386-sequent-ptx2\n"); exit (0);
-    }
-    if (strncmp(un.version, "V1", 2) == 0) { /* XXX is V1 correct? */
-	printf ("i386-sequent-ptx1\n"); exit (0);
-    }
-    printf ("i386-sequent-ptx\n"); exit (0);
-
-#endif
-
-#if defined (vax)
-# if !defined (ultrix)
-#  include <sys/param.h>
-#  if defined (BSD)
-#   if BSD == 43
-      printf ("vax-dec-bsd4.3\n"); exit (0);
-#   else
-#    if BSD == 199006
-      printf ("vax-dec-bsd4.3reno\n"); exit (0);
-#    else
-      printf ("vax-dec-bsd\n"); exit (0);
-#    endif
-#   endif
-#  else
-    printf ("vax-dec-bsd\n"); exit (0);
-#  endif
-# else
-    printf ("vax-dec-ultrix\n"); exit (0);
-# endif
-#endif
-
-#if defined (alliant) && defined (i860)
-  printf ("i860-alliant-bsd\n"); exit (0);
-#endif
-
-  exit (1);
-}
-EOF
-
-$CC_FOR_BUILD -o $dummy $dummy.c 2>/dev/null && SYSTEM_NAME=`$dummy` &&
-	{ echo "$SYSTEM_NAME"; exit; }
-
-# Apollos put the system type in the environment.
-
-test -d /usr/apollo && { echo ${ISP}-apollo-${SYSTYPE}; exit; }
-
-# Convex versions that predate uname can use getsysinfo(1)
-
-if [ -x /usr/convex/getsysinfo ]
-then
-    case `getsysinfo -f cpu_type` in
-    c1*)
-	echo c1-convex-bsd
-	exit ;;
-    c2*)
-	if getsysinfo -f scalar_acc
-	then echo c32-convex-bsd
-	else echo c2-convex-bsd
-	fi
-	exit ;;
-    c34*)
-	echo c34-convex-bsd
-	exit ;;
-    c38*)
-	echo c38-convex-bsd
-	exit ;;
-    c4*)
-	echo c4-convex-bsd
-	exit ;;
-    esac
-fi
 
 cat >&2 <<EOF
 $0: unable to guess system type

--- a/src/third_party/apache/aprutil/src/xml/expat/conftools/config.sub
+++ b/src/third_party/apache/aprutil/src/xml/expat/conftools/config.sub
@@ -1,8 +1,8 @@
 #! /bin/sh
 # Configuration validation subroutine script.
-#   Copyright 1992-2013 Free Software Foundation, Inc.
+#   Copyright 1992-2014 Free Software Foundation, Inc.
 
-timestamp='2013-10-01'
+timestamp='2014-01-01'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -68,7 +68,7 @@ Report bugs and patches to <config-patches@gnu.org>."
 version="\
 GNU config.sub ($timestamp)
 
-Copyright 1992-2013 Free Software Foundation, Inc.
+Copyright 1992-2014 Free Software Foundation, Inc.
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."


### PR DESCRIPTION
Update to httpd 2.4.12, upgrade apr-util to 1.5.4, update OpenSSL to 1.0.2, confirmed working on CentOS 6.6 with Apache 2.4.12 and mod-spdy with ssllabs & spdycheck.org.